### PR TITLE
Switch to swift-argument-parser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Commander",
-        "repositoryURL": "https://github.com/kylef/Commander",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,17 @@
-// swift-tools-version:5.1
-
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
     name: "reminders",
     dependencies: [
-        .package(url: "https://github.com/kylef/Commander", from: "0.9.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
     ],
     targets: [
         .target(
             name: "reminders",
-            dependencies: ["Commander"],
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
             path: "Sources"),
     ]
 )

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -1,0 +1,72 @@
+import ArgumentParser
+
+private let reminders = Reminders()
+
+private struct ShowLists: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Print the name of lists to pass to other commands")
+
+    func run() {
+        reminders.showLists()
+    }
+}
+
+private struct Show: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Print the items on the given list")
+
+    @Argument(
+        help: "The list to print items from, see 'show-lists' for names")
+    var listName: String
+
+    func run() {
+        reminders.showListItems(withName: self.listName)
+    }
+}
+
+private struct Add: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Add a reminder to a list")
+
+    @Argument(
+        help: "The list to add to, see 'show-lists' for names")
+    var listName: String
+
+    @Argument(
+        help: "The reminder contents")
+    var reminder: String
+
+    func run() {
+        reminders.addReminder(string: self.reminder, toListNamed: self.listName)
+    }
+}
+
+private struct Complete: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Complete a reminder")
+
+    @Argument(
+        help: "The list to complete a reminder on, see 'show-lists' for names")
+    var listName: String
+
+    @Argument(
+        help: "The index of the reminder to complete, see 'show' for indexes")
+    var index: Int
+
+    func run() {
+        reminders.complete(itemAtIndex: self.index, onListNamed: self.listName)
+    }
+}
+
+struct CLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "reminders",
+        abstract: "A utility for performing maths.",
+        subcommands: [
+            Add.self,
+            Complete.self,
+            Show.self,
+            ShowLists.self,
+        ]
+    )
+}

--- a/Sources/Reminders.swift
+++ b/Sources/Reminders.swift
@@ -3,12 +3,16 @@ import EventKit
 private let Store = EKEventStore()
 
 final class Reminders {
-    func requestAccess(completion: @escaping (_ granted: Bool) -> Void) {
+    static func requestAccess() -> Bool {
+        let semaphore = DispatchSemaphore(value: 0)
+        var grantedAccess = false
         Store.requestAccess(to: .reminder) { granted, _ in
-            DispatchQueue.main.async {
-                completion(granted)
-            }
+            grantedAccess = granted
+            semaphore.signal()
         }
+
+        semaphore.wait()
+        return grantedAccess
     }
 
     func showLists() {
@@ -63,6 +67,7 @@ final class Reminders {
         let reminder = EKReminder(eventStore: Store)
         reminder.calendar = calendar
         reminder.title = string
+        // reminder.dueDateComponents
 
         do {
             try Store.save(reminder, commit: true)

--- a/Sources/Reminders.swift
+++ b/Sources/Reminders.swift
@@ -67,7 +67,6 @@ final class Reminders {
         let reminder = EKReminder(eventStore: Store)
         reminder.calendar = calendar
         reminder.title = string
-        // reminder.dueDateComponents
 
         do {
             try Store.save(reminder, commit: true)

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,32 +1,8 @@
 import AppKit
-import Commander
 
-private let reminders = Reminders()
-private func createCLI() -> Group {
-    return Group {
-        $0.command("show-lists") {
-            reminders.showLists()
-        }
-        $0.command("show") { (listName: String) in
-            reminders.showListItems(withName: listName)
-        }
-        $0.command("complete") { (listName: String, index: Int) in
-            reminders.complete(itemAtIndex: index, onListNamed: listName)
-        }
-        $0.command("add") { (listName: String, parser: ArgumentParser) in
-            let string = parser.remainder.joined(separator: " ")
-            reminders.addReminder(string: string, toListNamed: listName)
-        }
-    }
+if Reminders.requestAccess() {
+    CLI.main()
+} else {
+    print("You need to grant reminders access")
+    exit(1)
 }
-
-reminders.requestAccess { granted in
-    if granted {
-        createCLI().run()
-    } else {
-        print("You need to grant reminders access")
-        exit(1)
-    }
-}
-
-NSApplication.shared.run()


### PR DESCRIPTION
This also fixes logs from calling `NSApplication.shared.run()`. This
seems to work with a semaphore instead, but we'll have to see how that
goes.