### PR TITLE
Add due date setting

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 
 private let reminders = Reminders()
 
@@ -36,8 +37,13 @@ private struct Add: ParsableCommand {
         help: "The reminder contents")
     var reminder: String
 
+    @Option(
+        name: .shortAndLong,
+        help: "The date the reminder is due")
+    var dueDate: DateComponents?
+
     func run() {
-        reminders.addReminder(string: self.reminder, toListNamed: self.listName)
+        reminders.addReminder(string: self.reminder, toListNamed: self.listName, dueDate: self.dueDate)
     }
 }
 

--- a/Sources/RemindersLibrary/NaturalLanguage.swift
+++ b/Sources/RemindersLibrary/NaturalLanguage.swift
@@ -1,0 +1,51 @@
+import ArgumentParser
+import Foundation
+
+private let calendar = Calendar.current
+private let allComponents: Set<Calendar.Component> = [
+    .era, .year, .yearForWeekOfYear, .quarter, .month,
+    .weekOfYear, .weekOfMonth, .weekday, .weekdayOrdinal, .day,
+    .hour, .minute, .second, .nanosecond,
+    .calendar, .timeZone
+]
+let timeComponents: Set<Calendar.Component> = [
+    .hour, .minute, .second, .nanosecond,
+]
+
+func calendarComponents(except removedComponents: Set<Calendar.Component> = []) -> Set<Calendar.Component> {
+
+    return allComponents.subtracting(removedComponents)
+}
+
+private func components(from string: String) -> DateComponents? {
+    guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.date.rawValue) else {
+        fatalError("error: failed to create NSDataDetector")
+    }
+
+    let range = NSRange(string.startIndex..<string.endIndex, in: string)
+
+    let matches = detector.matches(in: string, options: .anchored, range: range)
+    guard matches.count == 1, let match = matches.first, let date = match.date else {
+        return nil
+    }
+
+    let timeZone = match.timeZone ?? .current
+    let parsedComponents = calendar.dateComponents(in: timeZone, from: date)
+    if let noon = calendar.date(bySettingHour: 12, minute: 0, second: 0, of: date),
+        calendar.compare(date, to: noon, toGranularity: .minute) == .orderedSame
+    {
+        return calendar.dateComponents(calendarComponents(except: timeComponents), from: date)
+    }
+
+    return parsedComponents
+}
+
+extension DateComponents: ExpressibleByArgument {
+      public init?(argument: String) {
+          if let components = components(from: argument) {
+              self = components
+          } else {
+              return nil
+          }
+      }
+}

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -1,4 +1,5 @@
 import EventKit
+import Foundation
 
 private let Store = EKEventStore()
 private let dateFormatter = RelativeDateTimeFormatter()
@@ -73,11 +74,12 @@ public final class Reminders {
         semaphore.wait()
     }
 
-    func addReminder(string: String, toListNamed name: String) {
+    func addReminder(string: String, toListNamed name: String, dueDate: DateComponents?) {
         let calendar = self.calendar(withName: name)
         let reminder = EKReminder(eventStore: Store)
         reminder.calendar = calendar
         reminder.title = string
+        reminder.dueDateComponents = dueDate
 
         do {
             try Store.save(reminder, commit: true)

--- a/Tests/RemindersTests/NaturalLanguageTests.swift
+++ b/Tests/RemindersTests/NaturalLanguageTests.swift
@@ -24,7 +24,8 @@ final class NaturalLanguageTests: XCTestCase {
     func testTomorrowAtTime() throws {
         let components = try XCTUnwrap(DateComponents(argument: "tomorrow 9pm"))
         let tomorrow = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: 1, to: Date()))
-        let tomorrowAt9 = try XCTUnwrap(Calendar.current.date(bySetting: .hour, value: 21, of: tomorrow))
+        let tomorrowAt9 = try XCTUnwrap(
+            Calendar.current.date(bySettingHour: 21, minute: 0, second: 0, of: tomorrow))
         let expectedComponents = Calendar.current.dateComponents(calendarComponents(), from: tomorrowAt9)
 
         XCTAssertEqual(components, expectedComponents)

--- a/Tests/RemindersTests/NaturalLanguageTests.swift
+++ b/Tests/RemindersTests/NaturalLanguageTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import RemindersLibrary
+import XCTest
+
+final class NaturalLanguageTests: XCTestCase {
+    func testYesterday() throws {
+        let components = try XCTUnwrap(DateComponents(argument: "yesterday"))
+        let tomorrow = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -1, to: Date()))
+        let expectedComponents = Calendar.current.dateComponents(
+            calendarComponents(except: timeComponents), from: tomorrow)
+
+        XCTAssertEqual(components, expectedComponents)
+    }
+
+    func testTomorrow() throws {
+        let components = try XCTUnwrap(DateComponents(argument: "tomorrow"))
+        let tomorrow = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: 1, to: Date()))
+        let expectedComponents = Calendar.current.dateComponents(
+            calendarComponents(except: timeComponents), from: tomorrow)
+
+        XCTAssertEqual(components, expectedComponents)
+    }
+
+    func testTomorrowAtTime() throws {
+        let components = try XCTUnwrap(DateComponents(argument: "tomorrow 9pm"))
+        let tomorrow = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: 1, to: Date()))
+        let tomorrowAt9 = try XCTUnwrap(Calendar.current.date(bySetting: .hour, value: 21, of: tomorrow))
+        let expectedComponents = Calendar.current.dateComponents(calendarComponents(), from: tomorrowAt9)
+
+        XCTAssertEqual(components, expectedComponents)
+    }
+
+    func testRelativeDayCount() throws {
+        let components = try XCTUnwrap(DateComponents(argument: "in 2 days"))
+        let tomorrow = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: 2, to: Date()))
+        let expectedComponents = Calendar.current.dateComponents(
+            calendarComponents(except: timeComponents), from: tomorrow)
+
+        XCTAssertEqual(components, expectedComponents)
+    }
+
+    func testNextSaturday() throws {
+        let components = try XCTUnwrap(DateComponents(argument: "next saturday"))
+        let date = try XCTUnwrap(Calendar.current.date(from: components))
+
+        XCTAssertTrue(Calendar.current.isDateInWeekend(date))
+    }
+
+    // This unfortunately doesn't work
+    func disabled_testNextWeekend() throws {
+        let components = try XCTUnwrap(DateComponents(argument: "next weekend"))
+        let date = try XCTUnwrap(Calendar.current.date(from: components))
+
+        XCTAssertTrue(Calendar.current.isDateInWeekend(date))
+    }
+
+    func testSpecificDays() throws {
+        XCTAssertNotNil(DateComponents(argument: "next monday"))
+        XCTAssertNotNil(DateComponents(argument: "on monday at 9pm"))
+    }
+
+    func testIgnoreRandomString() {
+        XCTAssertNil(DateComponents(argument: "blah tomorrow 9pm"))
+    }
+}


### PR DESCRIPTION
This allows passing `--due-date` or `-d` to add a due date for the
reminder. There is way more logic than I would prefer here for a few
reasons.

1. EKReminder's due date is made up of date components. Whether or not
   you pass components containing values for times determines whether
   the reminder is saved as being due at a specific time, vs on a
   specific day.
2. Any way I could come up with to parse natural language date strings
   doesn't differentiate between if the user specified a time or not,
   and all Date objects contain time info.

Because of this I've made the tradeoff to assume a time was not passed
when we get the default time of 12pm from the parsed date. This means if
you pass `tomorrow at 12pm` as a due date, the time will be ignored and
only the date will be saved. Using `tomorrow at 12:01pm` works.

Thanks to this tip on using data detectors instead of deprecated NSDate
APIs! https://twitter.com/ChristinaMltn/status/1327642022782578691