### PR TITLE
Add flag to show completed items only

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -19,9 +19,12 @@ private struct Show: ParsableCommand {
     @Argument(
         help: "The list to print items from, see 'show-lists' for names")
     var listName: String
+    
+    @Flag(help: "Show completed items only")
+    var showCompleted = false
 
     func run() {
-        reminders.showListItems(withName: self.listName)
+        reminders.showListItems(withName: self.listName, showCompleted: showCompleted)
     }
 }
 

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -34,11 +34,11 @@ public final class Reminders {
         }
     }
 
-    func showListItems(withName name: String) {
+    func showListItems(withName name: String, showCompleted: Bool = false, showAll: Bool = false) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
-        self.reminders(onCalendar: calendar) { reminders in
+        self.reminders(onCalendar: calendar, showCompleted: showCompleted) { reminders in
             for (i, reminder) in reminders.enumerated() {
                 print(format(reminder, at: i))
             }
@@ -93,13 +93,22 @@ public final class Reminders {
     // MARK: - Private functions
 
     private func reminders(onCalendar calendar: EKCalendar,
+                                      showCompleted: Bool = false,
                                       completion: @escaping (_ reminders: [EKReminder]) -> Void)
     {
         let predicate = Store.predicateForReminders(in: [calendar])
         Store.fetchReminders(matching: predicate) { reminders in
             let reminders = reminders?
-                .filter { !$0.isCompleted }
+                .filter { self.showItem(item: $0, showCompleted: showCompleted) }
             completion(reminders ?? [])
+        }
+    }
+    
+    private func showItem(item: EKReminder, showCompleted: Bool) -> Bool {
+        if showCompleted {
+            return item.isCompleted
+        } else {
+            return !item.isCompleted
         }
     }
 


### PR DESCRIPTION
I'm interested in fetching completed items to see a history of what has been done in a day. This PR introduces a flag `--show-completed` to the `show` command that will display completed reminders only.