### PR TITLE
Show all items, in addition to showing only completed items

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -20,8 +20,14 @@ private struct Show: ParsableCommand {
         help: "The list to print items from, see 'show-lists' for names")
     var listName: String
 
+    @Flag(help: "Show completed items only")
+    var completed = false
+
+    @Flag(help: "Show all items")
+    var all = false
+
     func run() {
-        reminders.showListItems(withName: self.listName)
+        reminders.showListItems(withName: self.listName, showCompleted: completed, showAll: all)
     }
 }
 

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -34,11 +34,11 @@ public final class Reminders {
         }
     }
 
-    func showListItems(withName name: String) {
+    func showListItems(withName name: String, showCompleted: Bool = false, showAll: Bool = false) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
-        self.reminders(onCalendar: calendar) { reminders in
+        self.reminders(onCalendar: calendar, showCompleted: showCompleted, showAll: showAll) { reminders in
             for (i, reminder) in reminders.enumerated() {
                 print(format(reminder, at: i))
             }
@@ -93,13 +93,27 @@ public final class Reminders {
     // MARK: - Private functions
 
     private func reminders(onCalendar calendar: EKCalendar,
+                                      showCompleted: Bool = false,
+                                      showAll: Bool = false,
                                       completion: @escaping (_ reminders: [EKReminder]) -> Void)
     {
         let predicate = Store.predicateForReminders(in: [calendar])
         Store.fetchReminders(matching: predicate) { reminders in
             let reminders = reminders?
-                .filter { !$0.isCompleted }
+                .filter { self.showItem(item: $0, showCompleted: showCompleted, showAll: showAll) }
             completion(reminders ?? [])
+        }
+    }
+
+    private func showItem(item: EKReminder, showCompleted: Bool, showAll: Bool) -> Bool {
+        if showAll {
+            return true
+        } else {
+            if showCompleted {
+                return item.isCompleted
+            } else {
+                return !item.isCompleted
+            }
         }
     }
 


### PR DESCRIPTION
Builds on https://github.com/keith/reminders-cli/pull/29 to allow users to see all reminders instead of only active ones or completed ones.