### PR TITLE
Add --due-date to show

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -20,8 +20,13 @@ private struct Show: ParsableCommand {
         help: "The list to print items from, see 'show-lists' for names")
     var listName: String
 
+    @Option(
+        name: .shortAndLong,
+        help: "Show only reminders due on this date")
+    var dueDate: DateComponents?
+
     func run() {
-        reminders.showListItems(withName: self.listName)
+        reminders.showListItems(withName: self.listName, dueOn: self.dueDate)
     }
 }
 

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -34,13 +34,26 @@ public final class Reminders {
         }
     }
 
-    func showListItems(withName name: String) {
-        let calendar = self.calendar(withName: name)
+    func showListItems(withName name: String, dueOn dueDate: DateComponents?) {
         let semaphore = DispatchSemaphore(value: 0)
+        let calendar = Calendar.current
 
-        self.reminders(onCalendar: calendar) { reminders in
+        self.reminders(onCalendar: self.calendar(withName: name)) { reminders in
             for (i, reminder) in reminders.enumerated() {
-                print(format(reminder, at: i))
+                guard let dueDate = dueDate?.date else {
+                    print(format(reminder, at: i))
+                    continue
+                }
+
+                guard let reminderDueDate = reminder.dueDateComponents?.date else {
+                    continue
+                }
+
+                let sameDay = calendar.compare(
+                    reminderDueDate, to: dueDate, toGranularity: .day) == .orderedSame
+                if sameDay {
+                    print(format(reminder, at: i))
+                }
             }
 
             semaphore.signal()


### PR DESCRIPTION
This allows you to filter reminders in a list that are due on a specific
day, so you can do:

```
reminders show "To Do" --due-date tomorrow
```

To list all reminders on the `To Do` list that are due tomorrow. This
only filters based on whatever day you ask for, even if you ask for
something more specific. I'm not sure any more granularity than that is
useful.

This also prints the index of the reminder even if all other reminders
aren't printed, this means you could print just reminder `10` or
something. This makes it easier to make the number portable for
completing things from a previous command regardless of your filtering.

Fixes https://github.com/keith/reminders-cli/issues/28
