### PR TITLE
Add flags for showing completed reminders

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
@@ -6,11 +6,14 @@ let package = Package(
     platforms: [
         .macOS(.v10_15)
     ],
+    products: [
+        .executable(name: "reminders", targets: ["reminders"]),
+    ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.1.4")),
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "reminders",
             dependencies: ["RemindersLibrary"]
         ),

--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -20,13 +20,34 @@ private struct Show: ParsableCommand {
         help: "The list to print items from, see 'show-lists' for names")
     var listName: String
 
+    @Flag(help: "Show completed items only")
+    var onlyCompleted = false
+
+    @Flag(help: "Include completed items in output")
+    var includeCompleted = false
+
     @Option(
         name: .shortAndLong,
         help: "Show only reminders due on this date")
     var dueDate: DateComponents?
 
+    func validate() throws {
+        if self.onlyCompleted && self.includeCompleted {
+            throw ValidationError(
+                "Cannot specify both --show-completed and --only-completed")
+        }
+    }
+
     func run() {
-        reminders.showListItems(withName: self.listName, dueOn: self.dueDate)
+        var displayOptions = DisplayOptions.incomplete
+        if self.onlyCompleted {
+            displayOptions = .complete
+        } else if self.includeCompleted {
+            displayOptions = .all
+        }
+
+        reminders.showListItems(
+            withName: self.listName, dueOn: self.dueDate, displayOptions: displayOptions)
     }
 }
 


### PR DESCRIPTION
This adds `--only-completed` and `--included-completed` to `reminders show`.

Co-authored-by: Mauro Morales <contact@mauromorales.com>
Co-authored-by: Martin-Louis Bright <mlbright@gmail.com>
