### PR TITLE
Add new-list command

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -117,6 +117,24 @@ private struct Delete: ParsableCommand {
     }
 }
 
+private struct NewList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Create a new list")
+
+    @Argument(
+        help: "The name of the new list")
+    var listName: String
+
+    @Option(
+        name: .shortAndLong,
+        help: "The name of the source of the list, if all your lists use the same source it will default to that")
+    var source: String?
+
+    func run() {
+        reminders.newList(with: self.listName, source: self.source)
+    }
+}
+
 public struct CLI: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "reminders",
@@ -127,6 +145,7 @@ public struct CLI: ParsableCommand {
             Delete.self,
             Show.self,
             ShowLists.self,
+            NewList.self,
         ]
     )
 


### PR DESCRIPTION
This allows you to create a new list. By default it uses the underlying
source that all your others list use. If you use multiple sources it
forces you to pass `--source` with a name specified.
