### PR TITLE
Add show-all command

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -12,6 +12,20 @@ private struct ShowLists: ParsableCommand {
     }
 }
 
+private struct ShowAll: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Print all reminders")
+
+    @Option(
+        name: .shortAndLong,
+        help: "Show only reminders due on this date")
+    var dueDate: DateComponents?
+
+    func run() {
+        reminders.showAllReminders(dueOn: self.dueDate)
+    }
+}
+
 private struct Show: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Print the items on the given list")
@@ -182,6 +196,7 @@ public struct CLI: ParsableCommand {
             Show.self,
             ShowLists.self,
             NewList.self,
+            ShowAll.self,
         ]
     )
 


### PR DESCRIPTION
This shows all reminders across all lists, formatting them with the list
name, number, and then normal info:

```
$ reminders show-all
To Do: 1: Something
```

This is mostly useful when combined with `--due-date`, so you can show
all reminders due today, etc.
