### PR TITLE
Add private API for knowing if time should be used

### DIFF
--- a/Sources/RemindersLibrary/NaturalLanguage.swift
+++ b/Sources/RemindersLibrary/NaturalLanguage.swift
@@ -28,15 +28,20 @@ private func components(from string: String) -> DateComponents? {
         return nil
     }
 
-    let timeZone = match.timeZone ?? .current
-    let parsedComponents = calendar.dateComponents(in: timeZone, from: date)
-    if let noon = calendar.date(bySettingHour: 12, minute: 0, second: 0, of: date),
-        calendar.compare(date, to: noon, toGranularity: .minute) == .orderedSame
-    {
-        return calendar.dateComponents(calendarComponents(except: timeComponents), from: date)
+    var includeTime = true
+    if match.responds(to: NSSelectorFromString("timeIsSignificant")) {
+        includeTime = match.value(forKey: "timeIsSignificant") as? Bool ?? true
+    } else {
+        print("warning: timeIsSignificant is not available, please report this to keith/reminders-cli")
     }
 
-    return parsedComponents
+    let timeZone = match.timeZone ?? .current
+    let parsedComponents = calendar.dateComponents(in: timeZone, from: date)
+    if includeTime {
+        return parsedComponents
+    } else {
+        return calendar.dateComponents(calendarComponents(except: timeComponents), from: date)
+    }
 }
 
 extension DateComponents: ExpressibleByArgument {


### PR DESCRIPTION
When parsing the natural language text like 'today', you get back a full
NSDate with a time set at 12:00. Previously to understand this case I
would remove the time if it was noon, which also broke you manually
specifying '12:00'. It turns out there's a private API for this instead,
so this now safely calls that, warning if it breaks. This at least works
on macOS 13 but based on class dumps I think it has been around since at
least 2018.

Fixes https://github.com/keith/reminders-cli/issues/33
