### PR TITLE
update path to built program in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,5 @@ This requires a recent Xcode installation.
 ```
 $ cd reminders-cli
 $ make build-release
-$ cp .build/release/reminders /usr/local/bin/reminders
+$ cp .build/apple/Products/Release/reminders /usr/local/bin/reminders
 ```


### PR DESCRIPTION
Following the 'Building Manually' section of the README:

- https://github.com/keith/reminders-cli#building-manually

I found that the compiled executable wasn't at the path specified.

This PR updates the README to include the proper path.

I'm not sure if this is the canonical default now, or something to do with the version of `swift` I have installed, so please correct my if this change isn't universally applicable:

```
⇒  swift --version
swift-driver version: 1.62.15 Apple Swift version 5.7.2 (swiftlang-5.7.2.135.5 clang-1400.0.29.51)
Target: x86_64-apple-macosx13.0
```