### PR TITLE
add new cli command 'export-all' to export reminders as json

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "reminders",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v12)
     ],
     products: [
         .executable(name: "reminders", targets: ["reminders"]),

--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -12,6 +12,18 @@ private struct ShowLists: ParsableCommand {
     }
 }
 
+private struct ExportAll: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Export all reminders as JSON")
+
+    @Flag(help: "Pretty print the JSON data")
+    var prettyPrint = false
+
+    func run() {
+        reminders.exportAllReminders(prettyPrint: self.prettyPrint)
+    }
+}
+
 private struct ShowAll: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Print all reminders")
@@ -197,6 +209,7 @@ public struct CLI: ParsableCommand {
             ShowLists.self,
             NewList.self,
             ShowAll.self,
+            ExportAll.self,
         ]
     )
 

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -48,19 +48,23 @@ struct ReminderData: Encodable {
     let recurrenceRules: [EKRecurrenceRule]?
 
     public func encode(to encoder: Encoder) throws {
+        func formattedDate(date: Date) -> String {
+            return date.formatted(Date.ISO8601FormatStyle())
+        }
+
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(id, forKey: .id)
         try container.encode(calendarTitle, forKey: .calendarTitle)
         try container.encode(title, forKey: .title)
-        try container.encode(creationDate.map { $0.formatted(Date.ISO8601FormatStyle()) }, forKey: .creationDate)
-        try container.encode(lastModifiedDate.map { $0.formatted(Date.ISO8601FormatStyle()) }, forKey: .lastModifiedDate)
-        try container.encode(startDate.map { $0.formatted(Date.ISO8601FormatStyle()) }, forKey: .startDate)
-        try container.encode(dueDate.map { $0.formatted(Date.ISO8601FormatStyle()) }, forKey: .dueDate)
+        try container.encode(creationDate.map(formattedDate), forKey: .creationDate)
+        try container.encode(lastModifiedDate.map(formattedDate), forKey: .lastModifiedDate)
+        try container.encode(startDate.map(formattedDate), forKey: .startDate)
+        try container.encode(dueDate.map(formattedDate), forKey: .dueDate)
         try container.encode(notes, forKey: .notes)
         try container.encode(priority, forKey: .priority)
         try container.encode(isCompleted, forKey: .isCompleted)
-        try container.encode(completionDate.map { $0.formatted(Date.ISO8601FormatStyle()) }, forKey: .completionDate)
+        try container.encode(completionDate.map(formattedDate), forKey: .completionDate)
         // TODO: error: referencing instance method 'encode(_:forKey:)' on 'Array' requires that 'EKAlarm' conform to 'Encodable'
         //   Ref: https://developer.apple.com/documentation/eventkit/ekalarm
         // try container.encode(alarms, forKey: .alarms)


### PR DESCRIPTION
- partially fixes https://github.com/keith/reminders-cli/issues/30
- Announcement tweet: https://twitter.com/_devalias/status/1610194250024783872

---

This PR adds a new `export-all` option to the CLI, that will export all reminders in JSON format.

It also has an optional `--pretty-print` flag (defaults to `false`)

```shell
⇒  swift run reminders export-all --help
Building for debugging...
Build complete! (2.69s)
OVERVIEW: Export all reminders as JSON

USAGE: reminders export-all [--pretty-print]

OPTIONS:
  --pretty-print          Pretty print the JSON data
  -h, --help              Show help information.
```

The output format is a JSON object, where the keys are the name of the Reminder list, which contains an Array of the Reminder objects. Basically:

```json
{
  "MyList" : [
  ],
  "MyOtherList" : [
  ]
}
```

There are also some outstanding TODO notes for adding a few more bits of data:

```swift
// TODO: error: referencing instance method 'encode(_:forKey:)' on 'Array' requires that 'EKAlarm' conform to 'Encodable'
//   Ref: https://developer.apple.com/documentation/eventkit/ekalarm
// try container.encode(alarms, forKey: .alarms)
// TODO: error: referencing instance method 'encode(_:forKey:)' on 'Array' requires that 'EKRecurrenceRule' conform to 'Encodable'
//   Ref: https://developer.apple.com/documentation/eventkit/ekrecurrencerule
// try container.encode(recurrenceRules, forKey: .recurrenceRules)
```

Currently I believe completed reminders are filtered out automagically, as I am using:

```
self.reminders(on: self.getCalendars(), displayOptions: .incomplete)
```