### PR TITLE
add json output and expose external identifier

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -6,9 +6,13 @@ private let reminders = Reminders()
 private struct ShowLists: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Print the name of lists to pass to other commands")
-
+    @Option(
+        name: .shortAndLong,
+        help: "format, one of 'plain', 'json', or 'plainWithIds'. 'plainWithIds' substitutes a reminder's external identifier in place of its index")
+    var format: OutputFormat = .plain
+    
     func run() {
-        reminders.showLists()
+        reminders.showLists(outputFormat: format)
     }
 }
 
@@ -20,9 +24,14 @@ private struct ShowAll: ParsableCommand {
         name: .shortAndLong,
         help: "Show only reminders due on this date")
     var dueDate: DateComponents?
-
+    
+    @Option(
+        name: .shortAndLong,
+        help: "format, one of 'plain', 'json', or 'plainWithIds'. 'plainWithIds' substitutes a reminder's external identifier in place of its index")
+    var format: OutputFormat = .plain
+    
     func run() {
-        reminders.showAllReminders(dueOn: self.dueDate)
+        reminders.showAllReminders(dueOn: self.dueDate, outputFormat: format)
     }
 }
 
@@ -45,7 +54,12 @@ private struct Show: ParsableCommand {
         name: .shortAndLong,
         help: "Show only reminders due on this date")
     var dueDate: DateComponents?
-
+    
+    @Option(
+        name: .shortAndLong,
+        help: "format, one of 'plain', 'json', or 'plainWithIds'. 'plainWithIds' substitutes a reminder's external identifier in place of its index")
+    var format: OutputFormat = .plain
+    
     func validate() throws {
         if self.onlyCompleted && self.includeCompleted {
             throw ValidationError(
@@ -62,7 +76,7 @@ private struct Show: ParsableCommand {
         }
 
         reminders.showListItems(
-            withName: self.listName, dueOn: self.dueDate, displayOptions: displayOptions)
+            withName: self.listName, dueOn: self.dueDate, displayOptions: displayOptions, outputFormat: format)
     }
 }
 
@@ -89,13 +103,19 @@ private struct Add: ParsableCommand {
         name: .shortAndLong,
         help: "The priority of the reminder")
     var priority: Priority = .none
+    
+    @Option(
+        name: .shortAndLong,
+        help: "format, one of 'plain', 'json', or 'plainWithIds'. 'plainWithIds' substitutes a reminder's external identifier in place of its index")
+    var format: OutputFormat = .plain
 
     func run() {
         reminders.addReminder(
             string: self.reminder.joined(separator: " "),
             toListNamed: self.listName,
             dueDate: self.dueDate,
-            priority: priority)
+            priority: priority,
+            outputFormat: format)
     }
 }
 
@@ -109,8 +129,8 @@ private struct Complete: ParsableCommand {
     var listName: String
 
     @Argument(
-        help: "The index of the reminder to complete, see 'show' for indexes")
-    var index: Int
+        help: "The index or id of the reminder to delete, see 'show' for indexes")
+    var index: String
 
     func run() {
         reminders.complete(itemAtIndex: self.index, onListNamed: self.listName)
@@ -127,8 +147,8 @@ private struct Delete: ParsableCommand {
     var listName: String
 
     @Argument(
-        help: "The index of the reminder to delete, see 'show' for indexes")
-    var index: Int
+        help: "The index or id of the reminder to delete, see 'show' for indexes")
+    var index: String
 
     func run() {
         reminders.delete(itemAtIndex: self.index, onListNamed: self.listName)
@@ -151,8 +171,8 @@ private struct Edit: ParsableCommand {
     var listName: String
 
     @Argument(
-        help: "The index of the reminder to edit, see 'show' for indexes")
-    var index: Int
+        help: "The index or id of the reminder to delete, see 'show' for indexes")
+    var index: String
 
     @Argument(
         parsing: .remaining,

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -10,17 +10,91 @@ private func formattedDueDate(from reminder: EKReminder) -> String? {
     }
 }
 
-private extension EKReminder {
+extension EKReminder: Encodable {
+    enum EncodingKeys: String, CodingKey {
+        case externalId
+        case title
+        case notes
+        case url
+        case location
+        case completionDate
+        case isCompleted
+        case priority
+        case startDate
+        case dueDate
+        case list
+    }
+    
+    public func encode(to encoder:Encoder) throws {
+        var container = encoder.container(keyedBy: EncodingKeys.self)
+        try container.encode(self.calendarItemExternalIdentifier, forKey: .externalId)
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.isCompleted, forKey: .isCompleted)
+        try container.encode(self.priority, forKey: .priority)
+        try container.encode(self.calendar.title, forKey: .list)
+        
+        if let notes = self.notes {
+            try container.encode(notes, forKey: .notes)
+        }
+        
+        if let url = self.url {
+            try container.encode(url, forKey: .url)
+        }
+        
+        if let location = self.location {
+            try container.encode(location, forKey: .location)
+        }
+        
+        if let completionDate = self.completionDate {
+            try container.encode(completionDate, forKey: .completionDate)
+        }
+                        
+        if let startDateComponents = self.startDateComponents {
+            if #available(macOS 12.0, *) {
+                try container.encode(startDateComponents.date?.ISO8601Format(), forKey: .startDate)
+            } else {
+                try container.encode(startDateComponents.date?.description(with: .current), forKey: .startDate)
+            }
+        }
+                
+        if let dueDateComponents = self.dueDateComponents {
+            if #available(macOS 12.0, *) {
+                try container.encode(dueDateComponents.date?.ISO8601Format(), forKey: .dueDate)
+            } else {
+                try container.encode(dueDateComponents.date?.description(with: .current), forKey: .dueDate)
+            }
+        }                
+    }
+    
     var mappedPriority: EKReminderPriority {
         UInt(exactly: self.priority).flatMap(EKReminderPriority.init) ?? EKReminderPriority.none
     }
 }
 
-private func format(_ reminder: EKReminder, at index: Int, listName: String? = nil) -> String {
+extension String  {
+    var isNumber: Bool {
+        return !isEmpty && rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+    }
+}
+
+private func format(_ reminder: EKReminder, at index: Int, listName: String? = nil, outputFormat: OutputFormat) -> String {
     let dateString = formattedDueDate(from: reminder).map { " (\($0))" } ?? ""
     let priorityString = Priority(reminder.mappedPriority).map { " (priority: \($0))" } ?? ""
     let listString = listName.map { "\($0): " } ?? ""
-    return "\(listString)\(index): \(reminder.title ?? "<unknown>")\(dateString)\(priorityString)"
+
+    var indexString = ""
+    switch(outputFormat) {
+    case .plainWithIds:
+        indexString = reminder.calendarItemIdentifier
+    default:
+        indexString = "\(index)"
+    }
+
+    return "\(listString)\(indexString): \(reminder.title ?? "<unknown>")\(dateString)\(priorityString)"
+}
+
+public enum OutputFormat: String, ExpressibleByArgument {
+    case json, plainWithIds, plain        
 }
 
 public enum DisplayOptions: String, Decodable {
@@ -73,32 +147,42 @@ public final class Reminders {
         return self.getCalendars().map { $0.title }
     }
 
-    func showLists() {
-        for name in self.getListNames() {
-            print(name)
+    func showLists(outputFormat: OutputFormat) {
+        switch (outputFormat) {
+        case .json:
+            print(self.encodeToJson(data: self.getListNames()))
+        default:
+            for name in self.getListNames() {
+                print(name)
+            }
         }
     }
 
-    func showAllReminders(dueOn dueDate: DateComponents?) {
+    func showAllReminders(dueOn dueDate: DateComponents?, outputFormat: OutputFormat) {
         let semaphore = DispatchSemaphore(value: 0)
         let calendar = Calendar.current
 
         self.reminders(on: self.getCalendars(), displayOptions: .incomplete) { reminders in
-            for (i, reminder) in reminders.enumerated() {
-                let listName = reminder.calendar.title
-                guard let dueDate = dueDate?.date else {
-                    print(format(reminder, at: i, listName: listName))
-                    continue
-                }
-
-                guard let reminderDueDate = reminder.dueDateComponents?.date else {
-                    continue
-                }
-
-                let sameDay = calendar.compare(
-                    reminderDueDate, to: dueDate, toGranularity: .day) == .orderedSame
-                if sameDay {
-                    print(format(reminder, at: i, listName: listName))
+            switch (outputFormat) {
+            case .json:
+                print(self.encodeToJson(data: reminders))
+            default:
+                for (i, reminder) in reminders.enumerated() {
+                    let listName = reminder.calendar.title
+                    guard let dueDate = dueDate?.date else {
+                        print(format(reminder, at: i, listName: listName, outputFormat: outputFormat))
+                        continue
+                    }
+                    
+                    guard let reminderDueDate = reminder.dueDateComponents?.date else {
+                        continue
+                    }
+                    
+                    let sameDay = calendar.compare(
+                        reminderDueDate, to: dueDate, toGranularity: .day) == .orderedSame
+                    if sameDay {
+                        print(format(reminder, at: i, listName: listName, outputFormat: outputFormat))
+                    }
                 }
             }
 
@@ -108,25 +192,30 @@ public final class Reminders {
         semaphore.wait()
     }
 
-    func showListItems(withName name: String, dueOn dueDate: DateComponents?, displayOptions: DisplayOptions) {
+    func showListItems(withName name: String, dueOn dueDate: DateComponents?, displayOptions: DisplayOptions, outputFormat: OutputFormat) {
         let semaphore = DispatchSemaphore(value: 0)
         let calendar = Calendar.current
 
         self.reminders(on: [self.calendar(withName: name)], displayOptions: displayOptions) { reminders in
-            for (i, reminder) in reminders.enumerated() {
-                guard let dueDate = dueDate?.date else {
-                    print(format(reminder, at: i))
-                    continue
-                }
-
-                guard let reminderDueDate = reminder.dueDateComponents?.date else {
-                    continue
-                }
-
-                let sameDay = calendar.compare(
-                    reminderDueDate, to: dueDate, toGranularity: .day) == .orderedSame
-                if sameDay {
-                    print(format(reminder, at: i))
+            switch (outputFormat) {
+            case .json:
+                print(self.encodeToJson(data: reminders))
+            default:
+                for (i, reminder) in reminders.enumerated() {
+                    guard let dueDate = dueDate?.date else {
+                        print(format(reminder, at: i, outputFormat: outputFormat))
+                        continue
+                    }
+                    
+                    guard let reminderDueDate = reminder.dueDateComponents?.date else {
+                        continue
+                    }
+                    
+                    let sameDay = calendar.compare(
+                        reminderDueDate, to: dueDate, toGranularity: .day) == .orderedSame
+                    if sameDay {
+                        print(format(reminder, at: i, outputFormat: outputFormat))
+                    }
                 }
             }
 
@@ -177,12 +266,13 @@ public final class Reminders {
         }
     }
 
-    func edit(itemAtIndex index: Int, onListNamed name: String, newText: String) {
+    func edit(itemAtIndex index: String, onListNamed name: String, newText: String) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
         self.reminders(on: [calendar], displayOptions: .incomplete) { reminders in
-            guard let reminder = reminders[safe: index] else {
+            
+            guard let reminder = self.getReminder(from: reminders, at: index) else {
                 print("No reminder at index \(index) on \(name)")
                 exit(1)
             }
@@ -202,12 +292,13 @@ public final class Reminders {
         semaphore.wait()
     }
 
-    func complete(itemAtIndex index: Int, onListNamed name: String) {
+    func complete(itemAtIndex index: String, onListNamed name: String) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
         self.reminders(on: [calendar], displayOptions: .incomplete) { reminders in
-            guard let reminder = reminders[safe: index] else {
+            
+            guard let reminder = self.getReminder(from: reminders, at: index) else {
                 print("No reminder at index \(index) on \(name)")
                 exit(1)
             }
@@ -227,12 +318,12 @@ public final class Reminders {
         semaphore.wait()
     }
 
-    func delete(itemAtIndex index: Int, onListNamed name: String) {
+    func delete(itemAtIndex index: String, onListNamed name: String) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
         self.reminders(on: [calendar], displayOptions: .incomplete) { reminders in
-            guard let reminder = reminders[safe: index] else {
+            guard let reminder = self.getReminder(from: reminders, at: index) else {
                 print("No reminder at index \(index) on \(name)")
                 exit(1)
             }
@@ -251,7 +342,7 @@ public final class Reminders {
         semaphore.wait()
     }
 
-    func addReminder(string: String, toListNamed name: String, dueDate: DateComponents?, priority: Priority) {
+    func addReminder(string: String, toListNamed name: String, dueDate: DateComponents?, priority: Priority, outputFormat: OutputFormat) {
         let calendar = self.calendar(withName: name)
         let reminder = EKReminder(eventStore: Store)
         reminder.calendar = calendar
@@ -261,7 +352,14 @@ public final class Reminders {
 
         do {
             try Store.save(reminder, commit: true)
-            print("Added '\(reminder.title!)' to '\(calendar.title)'")
+            switch (outputFormat) {
+            case .json:
+                print(self.encodeToJson(data: reminder))
+            case .plainWithIds:
+                print("Added '\(reminder.calendarItemExternalIdentifier!)' to '\(calendar.title)'")
+            default:
+                print("Added '\(reminder.title!)' to '\(calendar.title)'")
+            }
         } catch let error {
             print("Failed to save reminder with error: \(error)")
             exit(1)
@@ -306,5 +404,14 @@ public final class Reminders {
     private func getCalendars() -> [EKCalendar] {
         return Store.calendars(for: .reminder)
                     .filter { $0.allowsContentModifications }
+    }
+    
+    private func getReminder(from reminders:[EKReminder], at index: String) -> EKReminder? {        
+        return (index.isNumber) ? reminders[safe: Int(argument: index)!] : reminders.filter({$0.calendarItemExternalIdentifier == index}).first
+    }
+    
+    private func encodeToJson(data: Encodable) -> String {
+        let encoded:Data = (try? JSONEncoder().encode(data)) ?? Data()
+        return String(data: encoded, encoding: .utf8) ?? ""
     }
 }


### PR DESCRIPTION
This PR adds support for formatting the output in JSON format for easy scripting (#30).  This is similar to #53 but adds a "--format" option to existing subcommands as I use the JSON output from add in some personal scripts ([example](https://github.com/nettleton/dotfiles/blob/ff78a9f2efaf1f4137a6f6394327d1b9b323c904/dot_config/fish/functions/extractReminders.fish#L26)).

```bash
$ reminders add MyList "some reminder" -f json | jq '.'
{
  "title": "some reminder",
  "isCompleted": false,
  "externalId": "BD2B26EF-38E1-40A7-90A4-C02ACA190145",
  "priority": 0,
  "list": "MyList"
}
```

2. Extends the --format option to use the external id in place of index.  I use the id for urls like "x-apple-reminderkit://REMCDReminder/$id" that open the specified reminder in the Reminders app, so being able to use the id directly instead of correlating to the array index makes things simpler.

```bash
$ reminders complete MyList BD2B26EF-38E1-40A7-90A4-C02ACA190145
Completed 'some reminder'
```