### PR TITLE
Add --notes option to edit command

### DIFF
--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -194,11 +194,21 @@ private struct Edit: ParsableCommand {
     @Argument(
         parsing: .remaining,
         help: "The new reminder contents")
-    var reminder: [String]
+    var reminder: [String] = []
+
+    @Option(
+        name: .shortAndLong,
+        help: "The new notes")
+    var notes: String?
 
     func run() {
-        reminders.edit(itemAtIndex: self.index, onListNamed: self.listName,
-                       newText: self.reminder.joined(separator: " "))
+        let newText = self.reminder.joined(separator: " ")
+        reminders.edit(
+            itemAtIndex: self.index,
+            onListNamed: self.listName,
+            newText: newText.isEmpty ? nil : newText,
+            newNotes: self.notes
+        )
     }
 }
 

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -212,7 +212,7 @@ public final class Reminders {
         }
     }
 
-    func edit(itemAtIndex index: String, onListNamed name: String, newText: String) {
+    func edit(itemAtIndex index: String, onListNamed name: String, newText: String?, newNotes: String?) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
@@ -223,7 +223,12 @@ public final class Reminders {
             }
 
             do {
-                reminder.title = newText
+                if let newText = newText {
+                    reminder.title = newText
+                }
+                if let newNotes = newNotes {
+                    reminder.notes = newNotes
+                }
                 try Store.save(reminder, commit: true)
                 print("Updated reminder '\(reminder.title!)'")
             } catch let error {

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -222,6 +222,11 @@ public final class Reminders {
                 exit(1)
             }
 
+            if newText == nil && newNotes == nil {
+                print("Nothing to update")
+                exit(1)
+            }
+
             do {
                 if let newText = newText {
                     reminder.title = newText


### PR DESCRIPTION
- Makes it possible to edit the notes of an existing reminder.
- Edit the title, or notes, or both at the same time (basically behaves as can reasonably be expected imo).
- I thought about making it possible to append to the existing notes but replacing it is more flexible and consistent with the way the title can already be edited.

This is a small part of what was requested on #59.