### PR TITLE
Add uncomplete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ $ reminders show Soon
 0 Ship reminders-cli
 ```
 
+#### Undo a completed item
+
+```
+$ reminders show Soon --only-completed
+0 Write README
+$ reminders uncomplete Soon 0
+Uncompleted 'Write README'
+$ reminders show Soon
+0 Write README
+```
+
 #### Edit an item on a list
 
 ```

--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -150,7 +150,25 @@ private struct Complete: ParsableCommand {
     var index: String
 
     func run() {
-        reminders.complete(itemAtIndex: self.index, onListNamed: self.listName)
+        reminders.complete(itemAtIndex: self.index, onListNamed: self.listName, isCompleted:true)
+    }
+}
+
+private struct Uncomplete: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Uncomplete a reminder")
+
+    @Argument(
+        help: "The list to uncomplete a reminder on, see 'show-lists' for names",
+        completion: .custom(listNameCompletion))
+    var listName: String
+
+    @Argument(
+        help: "The index or id of the reminder to delete, see 'show' for indexes")
+    var index: String
+
+    func run() {
+        reminders.complete(itemAtIndex: self.index, onListNamed: self.listName, isCompleted:false)
     }
 }
 
@@ -228,6 +246,7 @@ public struct CLI: ParsableCommand {
         subcommands: [
             Add.self,
             Complete.self,
+            Uncomplete.self,
             Delete.self,
             Edit.self,
             Show.self,

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -237,20 +237,27 @@ public final class Reminders {
         semaphore.wait()
     }
 
-    func complete(itemAtIndex index: String, onListNamed name: String) {
+    func complete(itemAtIndex index: String, onListNamed name: String, isCompleted :Bool) {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
+        var displayOptions = DisplayOptions.incomplete
+        var message = "Completed"
 
-        self.reminders(on: [calendar], displayOptions: .incomplete) { reminders in
+        if isCompleted == false {
+            displayOptions = DisplayOptions.complete
+            message = "Uncompleted"
+        }
+
+        self.reminders(on: [calendar], displayOptions: displayOptions) { reminders in
             guard let reminder = self.getReminder(from: reminders, at: index) else {
                 print("No reminder at index \(index) on \(name)")
                 exit(1)
             }
 
             do {
-                reminder.isCompleted = true
+                reminder.isCompleted = isCompleted
                 try Store.save(reminder, commit: true)
-                print("Completed '\(reminder.title!)'")
+                print("\(message) '\(reminder.title!)'")
             } catch let error {
                 print("Failed to save reminder with error: \(error)")
                 exit(1)


### PR DESCRIPTION
By default, the `show` command shows only `incomplete` items, so the user has to execute the `reminders show Todo --only-completed` command to retrieve completed items and their numbers. Then, the `reminders uncomplete Todo 9` command can be called to switch it back to the `incomplete` state.

Please bear in mind that I have 0 knowledge of Swift. I tried to make some changes and came up with this solution. I have tested it locally, and everything seems to be working.

Since the `uncomplete` operation uses the same flag field as the `complete` operation (isCompleted), instead of duplicating the complete function in `Reminders.swift`, I used the same function by just making it a parameter. Please review and let me know if there is anything that needs to be changed.