### PR TITLE
Fix permissions on macOS Sonoma

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,9 +8,11 @@ name: Swift
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: xcode-select
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Build
         run: swift build -Xswiftc -warnings-as-errors
       - name: Test

--- a/Sources/reminders/main.swift
+++ b/Sources/reminders/main.swift
@@ -1,9 +1,13 @@
 import Darwin
 import RemindersLibrary
 
-if Reminders.requestAccess() {
+switch Reminders.requestAccess() {
+case (true, _):
     CLI.main()
-} else {
-    print("You need to grant reminders access")
+case (false, let error):
+    print("error: you need to grant reminders access")
+    if let error {
+        print("error: \(error.localizedDescription)")
+    }
     exit(1)
 }


### PR DESCRIPTION
The old API now fails 100% of the time and you have to use the new API.
This also starts printing the returned error in this case for the
future.
