### PR TITLE
Don't add alarm for dates without times

### DIFF
--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -316,7 +316,7 @@ public final class Reminders {
         reminder.notes = notes
         reminder.dueDateComponents = dueDateComponents
         reminder.priority = Int(priority.value.rawValue)
-        if let dueDate = dueDateComponents?.date {
+        if let dueDate = dueDateComponents?.date, dueDateComponents?.hour != nil {
             reminder.addAlarm(EKAlarm(absoluteDate: dueDate))
         }
 


### PR DESCRIPTION
Natural language dates like `--due-date=today` don't have relevant time
info, so we don't add the time to the reminder. In this case if we add
an alarm with the date it just sets the time at midnight. In this case
we can just not add a time, which roughly matches the Reminders.app UI
where adding a date vs time is separate. If you pass `--due-date=9am` it
still sets the alarm correctly.

Fixes https://github.com/keith/reminders-cli/issues/79
