### PR TITLE
New feature: JSON reminder entry, as an independent command to add an entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ $ reminders show Soon
 3: Something really important (priority: high)
 ```
 
+#### Add a reminder via JSON input string
+
+```
+json_string='{
+  "title": "Buy groceries",
+  "notes": "Milk, eggs, bread, cheese",
+  "dueDate": "2025-02-15T10:24:00Z",
+  "priority": "medium",
+  "listName": "Groceries",
+  "recurring": "weekly",
+}'
+
+$ reminders add-json $json_string
+```
+
 #### See help for more examples
 
 ```

--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -157,6 +157,27 @@ private struct Add: ParsableCommand {
     }
 }
 
+private struct AddJSON: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Add a reminder as JSON")
+    
+    @Argument(
+        parsing: .remaining,
+        help: "The JSON string representing the reminder to add")
+    var JSONstring: [String]
+    
+    @Option(
+        name: .shortAndLong,
+        help: "format, either of 'plain' or 'json'")
+    var format: OutputFormat = .plain
+    
+    func run() {
+        reminders.addReminderJSON(
+            string: self.JSONstring.joined(separator: " "),
+            outputFormat: format)
+    }
+}
+
 private struct Complete: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Complete a reminder")
@@ -282,6 +303,7 @@ public struct CLI: ParsableCommand {
         abstract: "Interact with macOS Reminders from the command line",
         subcommands: [
             Add.self,
+            AddJSON.self,
             Complete.self,
             Uncomplete.self,
             Delete.self,

--- a/Sources/RemindersLibrary/EKReminder+Encodable.swift
+++ b/Sources/RemindersLibrary/EKReminder+Encodable.swift
@@ -1,6 +1,6 @@
 import EventKit
 
-extension EKReminder: Encodable {
+extension EKReminder: @retroactive Encodable {
     private enum EncodingKeys: String, CodingKey {
         case externalId
         case lastModified

--- a/Sources/RemindersLibrary/NaturalLanguage.swift
+++ b/Sources/RemindersLibrary/NaturalLanguage.swift
@@ -44,7 +44,7 @@ private func components(from string: String) -> DateComponents? {
     }
 }
 
-extension DateComponents: ExpressibleByArgument {
+extension DateComponents: @retroactive ExpressibleByArgument {
       public init?(argument: String) {
           if let components = components(from: argument) {
               self = components


### PR DESCRIPTION
Enabling setting the "recurring" properties of a reminder, and future extension, this pull requests adds a new command: add-json. 

This receives an input JSON-formatted string, containing all the reminders properties (including the listName).

```
json_string='{
  "title": "Buy groceries",
  "notes": "Milk, eggs, bread, cheese",
  "dueDate": "2025-02-15T10:24:00Z",
  "priority": "medium",
  "listName": "Groceries",
  "recurring": "weekly",
}'``` 

One could then invoke reminders simply as:

```
$ reminders add-json $json_string
``` 

In this way, simple shell aliases or other programmatic means can feed other properties to the reminder at the time of its creation. The ```format``` flag can be still specified (controlling the output of reminders), but I did not test it thoroughly.

Note I have explored startingDate, url, and other properties/attributes but failed to make them all work. The argument of "recurring" could definitely be improved. It currently accepts: daily, weekly, monthly, yearly. Maybe this could be of help to other people.

Thanks for your excellent work and for (indirectly) showing me "swift", which I am still a complete noob about. :)