### PR TITLE
feat: add --repeat flag for recurrence rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ $ reminders show Soon
 3: Something really important (priority: high)
 ```
 
+#### Add a recurring reminder
+
+```
+$ reminders add Soon Daily standup --due-date "tomorrow 9am" --repeat daily
+Added 'Daily standup' to 'Soon' (repeats: daily)
+$ reminders add Soon Weekly review --due-date "next friday 3pm" --repeat weekly
+Added 'Weekly review' to 'Soon' (repeats: weekly)
+$ reminders show Soon
+0: Ship reminders-cli
+1: Daily standup (in 10 hours) (repeats: daily)
+2: Weekly review (in 4 days) (repeats: weekly)
+```
+
+Supported values: `daily`, `weekly`, `monthly`, `yearly`
+
 #### Show reminders due on or by a date
 
 ```

--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -153,6 +153,11 @@ private struct Add: ParsableCommand {
         help: "The notes to add to the reminder")
     var notes: String?
 
+    @Option(
+        name: .shortAndLong,
+        help: "Set a recurrence rule: daily, weekly, monthly, yearly")
+    var `repeat`: Recurrence?
+
     func run() {
         reminders.addReminder(
             string: self.reminder.joined(separator: " "),
@@ -160,6 +165,7 @@ private struct Add: ParsableCommand {
             toListNamed: self.listName,
             dueDateComponents: self.dueDate,
             priority: priority,
+            recurrence: self.repeat,
             outputFormat: format)
     }
 }

--- a/Sources/RemindersLibrary/EKReminder+Encodable.swift
+++ b/Sources/RemindersLibrary/EKReminder+Encodable.swift
@@ -16,6 +16,7 @@ extension EKReminder: @retroactive Encodable {
         case startDate
         case dueDate
         case list
+        case recurrence
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -57,6 +58,19 @@ extension EKReminder: @retroactive Encodable {
         
         if let creationDate = self.creationDate {
             try container.encode(format(creationDate), forKey: .creationDate)
+        }
+
+        if let rule = self.recurrenceRules?.first {
+            let frequencyName: String
+            switch rule.frequency {
+            case .daily: frequencyName = "daily"
+            case .weekly: frequencyName = "weekly"
+            case .monthly: frequencyName = "monthly"
+            case .yearly: frequencyName = "yearly"
+            @unknown default: frequencyName = "unknown"
+            }
+            let recurrenceValue = rule.interval == 1 ? frequencyName : "every \(rule.interval) \(frequencyName)"
+            try container.encode(recurrenceValue, forKey: .recurrence)
         }
     }
     

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -16,13 +16,42 @@ private extension EKReminder {
     }
 }
 
+private func formattedRecurrence(from reminder: EKReminder) -> String? {
+    guard let rule = reminder.recurrenceRules?.first else { return nil }
+    switch rule.frequency {
+    case .daily:
+        if rule.interval == 1 {
+            return "daily"
+        }
+        return "every \(rule.interval) days"
+    case .weekly:
+        if rule.interval == 1 {
+            return "weekly"
+        }
+        return "every \(rule.interval) weeks"
+    case .monthly:
+        if rule.interval == 1 {
+            return "monthly"
+        }
+        return "every \(rule.interval) months"
+    case .yearly:
+        if rule.interval == 1 {
+            return "yearly"
+        }
+        return "every \(rule.interval) years"
+    @unknown default:
+        return "repeating"
+    }
+}
+
 private func format(_ reminder: EKReminder, at index: Int?, listName: String? = nil) -> String {
     let dateString = formattedDueDate(from: reminder).map { " (\($0))" } ?? ""
     let priorityString = Priority(reminder.mappedPriority).map { " (priority: \($0))" } ?? ""
+    let recurrenceString = formattedRecurrence(from: reminder).map { " (repeats: \($0))" } ?? ""
     let listString = listName.map { "\($0): " } ?? ""
     let notesString = reminder.notes.map { " (\($0))" } ?? ""
     let indexString = index.map { "\($0): " } ?? ""
-    return "\(listString)\(indexString)\(reminder.title ?? "<unknown>")\(notesString)\(dateString)\(priorityString)"
+    return "\(listString)\(indexString)\(reminder.title ?? "<unknown>")\(notesString)\(dateString)\(priorityString)\(recurrenceString)"
 }
 
 public enum OutputFormat: String, ExpressibleByArgument {
@@ -33,6 +62,30 @@ public enum DisplayOptions: String, Decodable {
     case all
     case incomplete
     case complete
+}
+
+public enum Recurrence: String, ExpressibleByArgument, CaseIterable {
+    case daily
+    case weekly
+    case monthly
+    case yearly
+
+    var frequency: EKRecurrenceFrequency {
+        switch self {
+            case .daily: return .daily
+            case .weekly: return .weekly
+            case .monthly: return .monthly
+            case .yearly: return .yearly
+        }
+    }
+
+    func toRecurrenceRule() -> EKRecurrenceRule {
+        return EKRecurrenceRule(
+            recurrenceWith: self.frequency,
+            interval: 1,
+            end: nil
+        )
+    }
 }
 
 public enum Priority: String, ExpressibleByArgument {
@@ -314,6 +367,7 @@ public final class Reminders {
         toListNamed name: String,
         dueDateComponents: DateComponents?,
         priority: Priority,
+        recurrence: Recurrence?,
         outputFormat: OutputFormat)
     {
         let calendar = self.calendar(withName: name)
@@ -326,6 +380,9 @@ public final class Reminders {
         if let dueDate = dueDateComponents?.date, dueDateComponents?.hour != nil {
             reminder.addAlarm(EKAlarm(absoluteDate: dueDate))
         }
+        if let recurrence = recurrence {
+            reminder.addRecurrenceRule(recurrence.toRecurrenceRule())
+        }
 
         do {
             try Store.save(reminder, commit: true)
@@ -333,7 +390,11 @@ public final class Reminders {
             case .json:
                 print(encodeToJson(data: reminder))
             default:
-                print("Added '\(reminder.title!)' to '\(calendar.title)'")
+                var message = "Added '\(reminder.title!)' to '\(calendar.title)'"
+                if let recurrence = recurrence {
+                    message += " (repeats: \(recurrence.rawValue))"
+                }
+                print(message)
             }
         } catch let error {
             print("Failed to save reminder with error: \(error)")


### PR DESCRIPTION
## Summary
- Adds `--repeat` flag to `add` command with support for: `daily`, `weekly`, `monthly`, `yearly`
- Displays recurrence info in `show`/`show-all` plain text output (e.g. `(repeats: daily)`)
- Includes `recurrence` field in JSON output format
- Adds README documentation for the new flag

## Usage
```bash
reminders add Soon "Daily standup" --due-date "tomorrow 9am" --repeat daily
reminders add Soon "Weekly review" --due-date "next friday 3pm" --repeat weekly
```

## Implementation
Uses EventKit's `EKRecurrenceRule` and `addRecurrenceRule()` — standard public API available since macOS 10.15.

Note: EventKit only supports daily/weekly/monthly/yearly frequencies. Hourly and sub-daily recurrence are not exposed by Apple's public API.

Closes #104