### PR TITLE
fix: allow deleting a reminder by external id after it's been completed

### DIFF
--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -288,7 +288,17 @@ public final class Reminders {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
-        self.reminders(on: [calendar], displayOptions: .incomplete) { reminders in
+        // Numeric indexes are only meaningful against the same display set that
+        // `show` uses by default (incomplete-only), so keep that scope when the
+        // caller passes a plain integer index — otherwise a numeric index would
+        // resolve against a differently-ordered/sized array than the one the
+        // user actually saw. External identifiers are stable regardless of
+        // completion state, so widen the fetch to `.all` in that case, so a
+        // reminder already marked complete can still be found and deleted by
+        // its id instead of failing with "No reminder at index ...".
+        let displayOptions: DisplayOptions = Int(index) == nil ? .all : .incomplete
+
+        self.reminders(on: [calendar], displayOptions: displayOptions) { reminders in
             guard let reminder = self.getReminder(from: reminders, at: index) else {
                 print("No reminder at index \(index) on \(name)")
                 exit(1)


### PR DESCRIPTION
## Bug

`reminders delete <list> <id>` fails with `No reminder at index <id> on <list>` for a reminder that has already been marked complete, even when `<id>` is a valid `calendarItemExternalIdentifier`.

Repro:
```
$ reminders add Soon "Task"
$ reminders show Soon --format json   # note externalId
$ reminders complete Soon 0
$ reminders delete Soon <externalId>
No reminder at index <externalId> on Soon
```

## Cause

`delete(itemAtIndex:onListNamed:)` always fetches with `displayOptions: .incomplete` before searching for the given index/id:

```swift
self.reminders(on: [calendar], displayOptions: .incomplete) { reminders in
    guard let reminder = self.getReminder(from: reminders, at: index) else { ...
```

Once the reminder is completed it's no longer in that fetched set, so lookup fails regardless of whether the id itself is valid. `setComplete`/`edit` have the same `.incomplete`-only pattern; I left those alone to keep this PR minimal, but flagging in case they're wanted too (e.g. `uncomplete` on a reminder that was actually completed via Reminders.app rather than this CLI can hit the same class of issue).

## Fix

Widen the fetch to `.all` only when the argument is an external id (non-numeric). Numeric indexes stay scoped to `.incomplete`, since that's the same set `show`'s default output enumerates — widening that path too would let a numeric index silently resolve against a different array than what the user actually saw.

```swift
let displayOptions: DisplayOptions = Int(index) == nil ? .all : .incomplete
```

## Testing

No automated test added — `Reminders` talks directly to a live `EKEventStore()` with no injection seam, and CI (`macos-14` runner) has no granted Reminders permission, so this isn't exercisable in `swift test` today. That's consistent with the existing suite, which only covers pure date-parsing logic in `NaturalLanguageTests.swift`.

Manually verified against a real Reminders store with the built binary:
- create → complete → `delete <externalId>` → now succeeds, item is gone from `show --include-completed` (previously failed with the error above)
- create → `delete <numeric index>` on an incomplete item → unchanged, still works exactly as before
- `swift build -Xswiftc -warnings-as-errors` and `swift test -Xswiftc -warnings-as-errors` both pass locally (matching `.github/workflows/swift.yml`)

## Disclosure

I ran into this bug while automating reminder cleanup from a script and diagnosed/wrote the fix with AI assistance (an agent reading the source, reproducing the bug against a live Reminders store, and drafting this patch), which I reviewed and tested manually as described above. Happy to adjust the approach (e.g. widen `setComplete`/`edit` too, or handle this differently) if you'd prefer.