### PR TITLE
Add --due-date and --clear-due-date to the edit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ $ reminders show Soon
 ```
 $ reminders edit Soon 0 Some edited text
 Updated reminder 'Some edited text'
+$ reminders edit Soon 0 --due-date "tomorrow 9am"
+Updated reminder 'Some edited text'
+$ reminders edit Soon 0 --clear-due-date
+Updated reminder 'Some edited text'
 $ reminders show Soon
 0 Ship reminders-cli
 1 Some edited text

--- a/Sources/RemindersLibrary/CLI.swift
+++ b/Sources/RemindersLibrary/CLI.swift
@@ -242,14 +242,27 @@ private struct Edit: ParsableCommand {
         help: "The notes to set on the reminder, overwriting previous notes")
     var notes: String?
 
+    @Option(
+        name: .shortAndLong,
+        help: "The new date the reminder is due")
+    var dueDate: DateComponents?
+
+    @Flag(help: "Remove the due date from the reminder")
+    var clearDueDate = false
+
     @Argument(
         parsing: .remaining,
         help: "The new reminder contents")
     var reminder: [String] = []
 
     func validate() throws {
-        if self.reminder.isEmpty && self.notes == nil {
-            throw ValidationError("Must specify either new reminder content or new notes")
+        if self.dueDate != nil && self.clearDueDate {
+            throw ValidationError("Cannot specify both --due-date and --clear-due-date")
+        }
+
+        if self.reminder.isEmpty && self.notes == nil && self.dueDate == nil && !self.clearDueDate {
+            throw ValidationError(
+                "Must specify either new reminder content, new notes, or a due date change")
         }
     }
 
@@ -259,7 +272,9 @@ private struct Edit: ParsableCommand {
             itemAtIndex: self.index,
             onListNamed: self.listName,
             newText: newText.isEmpty ? nil : newText,
-            newNotes: self.notes
+            newNotes: self.notes,
+            newDueDateComponents: self.dueDate,
+            clearDueDate: self.clearDueDate
         )
     }
 }

--- a/Sources/RemindersLibrary/Reminders.swift
+++ b/Sources/RemindersLibrary/Reminders.swift
@@ -230,7 +230,14 @@ public final class Reminders {
         }
     }
 
-    func edit(itemAtIndex index: String, onListNamed name: String, newText: String?, newNotes: String?) {
+    func edit(
+        itemAtIndex index: String,
+        onListNamed name: String,
+        newText: String?,
+        newNotes: String?,
+        newDueDateComponents: DateComponents? = nil,
+        clearDueDate: Bool = false)
+    {
         let calendar = self.calendar(withName: name)
         let semaphore = DispatchSemaphore(value: 0)
 
@@ -243,6 +250,23 @@ public final class Reminders {
             do {
                 reminder.title = newText ?? reminder.title
                 reminder.notes = newNotes ?? reminder.notes
+
+                if clearDueDate {
+                    reminder.dueDateComponents = nil
+                    for alarm in reminder.alarms ?? [] {
+                        reminder.removeAlarm(alarm)
+                    }
+                } else if let newDueDateComponents {
+                    reminder.dueDateComponents = newDueDateComponents
+                    for alarm in reminder.alarms ?? [] {
+                        reminder.removeAlarm(alarm)
+                    }
+
+                    if let dueDate = newDueDateComponents.date, newDueDateComponents.hour != nil {
+                        reminder.addAlarm(EKAlarm(absoluteDate: dueDate))
+                    }
+                }
+
                 try Store.save(reminder, commit: true)
                 print("Updated reminder '\(reminder.title!)'")
             } catch let error {


### PR DESCRIPTION
`reminders add` supports `-d/--due-date`, but `reminders edit` had no way to change a reminder's due date - only its title and notes. Changing a due date meant deleting and re-adding the reminder.

This adds to `edit`:

- `-d/--due-date <date>` - set a new due date, parsed by the same `DateComponents` natural-language parser `add` uses
- `--clear-due-date` - remove the due date entirely

Behaviour details:

- Setting a new due date clears existing alarms and adds an absolute alarm when the parsed date includes a time, mirroring `add`.
- Clearing the due date also clears alarms, so a stale notification doesn't fire.
- The two flags are mutually exclusive.
- `edit` now accepts a due-date change on its own; previously validation required new text or notes.

Tested manually against a scratch list on macOS: setting a date, setting a date with a time, clearing, combining a date change with new text, and both validation errors.

```
$ reminders edit Soon 0 --due-date "tomorrow 9am"
Updated reminder 'Some edited text'
$ reminders edit Soon 0 --clear-due-date
Updated reminder 'Some edited text'
```

Branched off `main` and independent of #107 (--repeat); no overlapping changes.